### PR TITLE
feat: Migrate Svelte 4 syntax to Svelte 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3835,21 +3835,6 @@
         }
       }
     },
-    "node_modules/svelte-check/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/svelte-check/node_modules/readdirp": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",

--- a/src/lib/widgets/nav.svelte
+++ b/src/lib/widgets/nav.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 
 	function activeClass(url: string): string {
-		const isActive = url === $page.url.pathname;
+		const isActive = url === page.url.pathname;
 		if (isActive) {
 			return 'active';
 		}


### PR DESCRIPTION
This commit migrates the usage of the Svelte 4 `$page` store in `src/lib/widgets/nav.svelte` to the new Svelte 5 `$app/state` module.

The following changes were made:
- Changed the import from `$app/stores` to `$app/state`.
- Removed the `$` prefix when accessing the `page` object.

Verification of the changes by running the build process was not possible due to repeated timeouts in the environment. The changes were made according to the official Svelte 5 migration guide and have been visually inspected.