### PR TITLE
Simplify map layout and float controls

### DIFF
--- a/src/lib/components/map.svelte
+++ b/src/lib/components/map.svelte
@@ -1,21 +1,19 @@
 <script lang="ts">
 	import { invalidateAll } from '$app/navigation';
 	import { onMount } from 'svelte';
-	import { House, Sword } from 'lucide-svelte';
+	import { House, Sword, X } from 'lucide-svelte';
 	import { JobSubType, type CityDefinition } from '../../gen/v1/masterdata_pb';
 	import type { Monster } from '../../gen/v1/domain_pb';
 	import type { BattleJobInfo, ProductionJobInfo } from '../../gen/v1/service_pb';
 	import { protoToMilliseconds } from '$lib/utils/prototime';
-	import { gameStateStore } from '$lib/stores/gamestate.svelte';
 	import { getServicesContext } from '$lib/service/context';
 	import JobDefinitionCard from '$lib/widgets/job-definition-card.svelte';
 	import Button from '$lib/components/ui/button/button.svelte';
 	import MultiSelect from '$lib/components/ui/multi-select/multi-select.svelte';
 
-	type MapJobKind = 'production' | 'battle';
 	type MapJob = {
 		id: string;
-		kind: MapJobKind;
+		kind: 'production' | 'battle';
 		subType: JobSubType;
 		x: number;
 		y: number;
@@ -23,8 +21,11 @@
 		routeInfo: ProductionJobInfo['routeInfo'] | BattleJobInfo['routeInfo'];
 	};
 
-	type SubtypeMeta = {
-		label: string;
+	type MapData = {
+		width: number;
+		height: number;
+		tileSet: { tileSetId: number; source: string }[];
+		layer: number[][];
 	};
 
 	let {
@@ -37,13 +38,28 @@
 		cities: CityDefinition[];
 		productionJobs: ProductionJobInfo[];
 		battleJobs: BattleJobInfo[];
-		[key: string]: unknown;
 	} = $props();
 
 	const TILE_SIZE = 10;
 	const FALLBACK_WALK_SPEED = 1;
+	const SUBTYPE_LABELS: Partial<Record<JobSubType, string>> = {
+		[JobSubType.WOODCUTTING]: 'Woodcutting',
+		[JobSubType.MINING]: 'Mining',
+		[JobSubType.HARVESTING]: 'Harvesting',
+		[JobSubType.FISHING]: 'Fishing',
+		[JobSubType.SMELTING]: 'Smelting',
+		[JobSubType.WOODWORKING]: 'Woodworking',
+		[JobSubType.FISHERY]: 'Fishery',
+		[JobSubType.FOOD_PROCESSING]: 'Food Processing',
+		[JobSubType.COOKING]: 'Cooking',
+		[JobSubType.WEAPON_CRAFTING]: 'Weapon Crafting',
+		[JobSubType.ARMOR_CRAFTING]: 'Armor Crafting',
+		[JobSubType.BATTLE]: 'Battle',
+		[JobSubType.TRANSPORT]: 'Transport',
+	};
 	const { jobs: jobService, battles: battleService } = getServicesContext();
 
+	let canvas: HTMLCanvasElement;
 	let mapPixelWidth = $state(1000);
 	let mapPixelHeight = $state(1000);
 	let selectedJobId = $state<string | undefined>(undefined);
@@ -89,21 +105,16 @@
 	const selectedJob = $derived(visibleJobs.find((job) => job.id === selectedJobId));
 	const availableMonsters = $derived(monsters.filter((monster) => !monster.participant?.jobEntityId));
 	const selectedMonster = $derived(availableMonsters.find((monster) => monster.entity?.id === selectedMonsterId));
-	const groupedBySubtype = $derived.by(() => {
-		const groups = new Map<JobSubType, { count: number; meta: SubtypeMeta }>();
+	const subtypeOptions = $derived.by(() => {
+		const counts: Record<number, number> = {};
 		for (const job of allJobs) {
-			const curr = groups.get(job.subType);
-			if (curr) {
-				curr.count += 1;
-				continue;
-			}
-			groups.set(job.subType, { count: 1, meta: getSubtypeMeta(job.subType) });
+			counts[job.subType] = (counts[job.subType] ?? 0) + 1;
 		}
-		return Array.from(groups.entries());
+		return Object.entries(counts).map(([value, count]) => {
+			const subType = Number(value) as JobSubType;
+			return { value: subType, count, label: SUBTYPE_LABELS[subType] ?? 'Production' };
+		});
 	});
-	const subtypeOptions = $derived(
-		groupedBySubtype.map(([value, group]) => ({ value, label: group.meta.label, count: group.count })),
-	);
 
 	$effect(() => {
 		if (!selectedJobId) return;
@@ -114,88 +125,57 @@
 	});
 
 	onMount(() => {
-		let app: any;
-		let isMounted = true;
+		let app: import('pixi.js').Application | undefined;
+		let cancelled = false;
 
-		(async () => {
+		async function renderMap(): Promise<void> {
 			const PIXI = await import('pixi.js');
 			const response = await fetch('/assets/map.json');
-			const mapData = await response.json();
-			if (!isMounted) return;
+			if (!response.ok) throw new Error(`Could not load map (${response.status})`);
+			const mapData = (await response.json()) as MapData;
+			if (cancelled) return;
 
 			mapPixelWidth = mapData.width * TILE_SIZE;
 			mapPixelHeight = mapData.height * TILE_SIZE;
 
-			app = new PIXI.Application();
-			await app.init({ width: mapPixelWidth, height: mapPixelHeight });
-			if (!isMounted) return;
-
-			const canvasHost = document.getElementById('map-canvas');
-			if (canvasHost) {
-				canvasHost.innerHTML = '';
-				canvasHost.appendChild(app.canvas);
+			const nextApp = new PIXI.Application();
+			await nextApp.init({ canvas, width: mapPixelWidth, height: mapPixelHeight, antialias: false });
+			if (cancelled) {
+				nextApp.destroy(false, { children: true });
+				return;
 			}
+			app = nextApp;
 
-			const textures = await Promise.all(
-				mapData.tileSet.map((tile: { source: string }) => PIXI.Assets.load(`/assets/${tile.source}`)),
+			const textureEntries = await Promise.all(
+				mapData.tileSet.map(
+					async (tile) => [tile.tileSetId, await PIXI.Assets.load(`/assets/${tile.source}`)] as const,
+				),
 			);
-			if (!isMounted) return;
+			if (cancelled) return;
+			const textures = new Map(textureEntries);
+			const terrain = new PIXI.Container();
 
-			for (let y = 0; y < mapData.height; y++) {
-				for (let x = 0; x < mapData.width; x++) {
-					const tileId = mapData.layer[y][x];
-					const tileInfo = mapData.tileSet.find((t: { tileSetId: number }) => t.tileSetId === tileId);
-					if (!tileInfo) continue;
-
-					const texture = textures[mapData.tileSet.indexOf(tileInfo)];
+			for (const [y, row] of mapData.layer.entries()) {
+				for (const [x, tileId] of row.entries()) {
+					const texture = textures.get(tileId);
+					if (!texture) continue;
 					const sprite = new PIXI.Sprite(texture);
-					sprite.width = TILE_SIZE;
-					sprite.height = TILE_SIZE;
+					sprite.setSize(TILE_SIZE);
 					sprite.x = x * TILE_SIZE;
 					sprite.y = y * TILE_SIZE;
-					app.stage.addChild(sprite);
+					terrain.addChild(sprite);
 				}
 			}
-		})();
+			app.stage.addChild(terrain);
+		}
+
+		void renderMap().catch((error) => console.error('Failed to render map', error));
 
 		return () => {
-			isMounted = false;
-			app?.destroy(true, { children: true });
+			cancelled = true;
+			app?.destroy(false, { children: true });
 		};
 	});
-
-	function getSubtypeMeta(subType: JobSubType): SubtypeMeta {
-		switch (subType) {
-			case JobSubType.WOODCUTTING:
-				return { label: 'Woodcutting' };
-			case JobSubType.MINING:
-				return { label: 'Mining' };
-			case JobSubType.HARVESTING:
-				return { label: 'Harvesting' };
-			case JobSubType.FISHING:
-				return { label: 'Fishing' };
-			case JobSubType.SMELTING:
-				return { label: 'Smelting' };
-			case JobSubType.WOODWORKING:
-				return { label: 'Woodworking' };
-			case JobSubType.FISHERY:
-				return { label: 'Fishery' };
-			case JobSubType.FOOD_PROCESSING:
-				return { label: 'Food Processing' };
-			case JobSubType.COOKING:
-				return { label: 'Cooking' };
-			case JobSubType.WEAPON_CRAFTING:
-				return { label: 'Weapon Crafting' };
-			case JobSubType.ARMOR_CRAFTING:
-				return { label: 'Armor Crafting' };
-			case JobSubType.BATTLE:
-				return { label: 'Battle' };
-			case JobSubType.TRANSPORT:
-				return { label: 'Transport' };
-			default:
-				return { label: 'Production' };
-		}
-	}
 
 	function getDistance(a: { x: number; y: number }, b: { x: number; y: number }): number {
 		const dx = a.x - b.x;
@@ -268,18 +248,13 @@
 	}
 </script>
 
-<div class="space-y-3">
-	<MultiSelect label="Jobs" options={subtypeOptions} bind:selected={subtypeFilters} />
+<div class="relative h-[calc(100vh-1rem)] min-h-96 overflow-hidden rounded-xl border border-border bg-muted shadow-sm">
+	<div class="absolute inset-0 overflow-auto">
+		<div class="relative" style="width: {mapPixelWidth}px; height: {mapPixelHeight}px;">
+			<canvas bind:this={canvas} class="absolute inset-0" aria-hidden="true"></canvas>
 
-	<div class="grid grid-cols-[minmax(0,1fr)_16rem] gap-4">
-		<div
-			class="relative overflow-hidden rounded-lg border border-border"
-			style="width: {mapPixelWidth}px; height: {mapPixelHeight}px; max-width: 100%;"
-		>
-			<div id="map-canvas" class="absolute inset-0" aria-hidden="true"></div>
-
-			<div class="absolute inset-0">
-				{#each cities as city}
+			<div class="pointer-events-none absolute inset-0">
+				{#each cities as city (city.id)}
 					{#if city.position}
 						<div
 							class="absolute z-20"
@@ -294,7 +269,7 @@
 					{/if}
 				{/each}
 
-				{#each monsters as monster}
+				{#each monsters as monster (monster.entity?.id)}
 					{#if monster.position}
 						<div
 							class="absolute z-30"
@@ -309,10 +284,11 @@
 					{/if}
 				{/each}
 
-				{#each visibleJobs as job}
+				{#each visibleJobs as job (job.id)}
 					<button
 						type="button"
-						class="absolute z-40 h-6 w-6 rounded-full border-2 border-white shadow {job.kind === 'battle'
+						class="pointer-events-auto absolute z-40 h-6 w-6 rounded-full border-2 border-white shadow {job.kind ===
+						'battle'
 							? 'bg-red-600 hover:bg-red-700'
 							: 'bg-blue-600 hover:bg-blue-700'} {selectedJobId === job.id ? 'ring-2 ring-offset-2 ring-black/40' : ''}"
 						style="left: {job.x * TILE_SIZE}px; top: {job.y * TILE_SIZE}px; transform: translate(-50%, -50%);"
@@ -321,77 +297,80 @@
 							selectedMonsterId = undefined;
 							startError = undefined;
 						}}
-						title={job.definition?.id ?? job.id}
+						title={job.definition?.name ?? job.id}
+						aria-label={`Select ${job.definition?.name ?? 'job'}`}
 					></button>
 				{/each}
 			</div>
 		</div>
+	</div>
 
-		<aside class="h-fit rounded-lg border border-border bg-card p-3">
-			{#if selectedJob}
-				<JobDefinitionCard
-					job={{ definition: selectedJob.definition, routeInfo: selectedJob.routeInfo }}
-					selected={true}
-					interactive={false}
-					class="mb-3"
-				/>
+	<div class="absolute left-3 top-3 z-50 rounded-md shadow-lg sm:left-4 sm:top-4">
+		<MultiSelect label="Jobs" options={subtypeOptions} bind:selected={subtypeFilters} />
+	</div>
 
-				<div class="mb-2 text-xs font-medium text-muted-foreground">Available Monsters</div>
-				<div class="max-h-56 space-y-1.5 overflow-y-auto pr-1">
-					{#if availableMonsters.length === 0}
-						<div class="rounded border border-dashed border-border bg-muted px-2 py-2 text-xs text-muted-foreground">
-							All monsters are currently busy.
-						</div>
-					{:else}
-						{#each availableMonsters as monster}
-							{@const eta = estimateMonsterTravel(selectedJob, monster)}
-							<button
-								type="button"
-								class="w-full rounded border px-2 py-1.5 text-left text-xs transition {selectedMonsterId ===
-								monster.entity?.id
-									? 'border-primary/40 bg-secondary'
-									: 'border-border bg-card hover:border-border'}"
-								onclick={() => (selectedMonsterId = monster.entity?.id)}
-							>
-								<div class="font-medium text-foreground">{monster.identity?.name}</div>
-								<div class="text-muted-foreground">
-									Lv {monster.stat?.level} | Stamina {monster.stat?.stamina}/{monster.stat?.maxStamina}
-								</div>
-								<div class="text-muted-foreground">
-									Distance {Math.round(eta.distance * 100) / 100}m | ETA {formatDuration(eta.seconds)}
-								</div>
-							</button>
-						{/each}
-					{/if}
+	{#if selectedJob}
+		<aside
+			class="absolute inset-x-3 bottom-3 z-50 max-h-[calc(100%-5rem)] overflow-y-auto rounded-lg border border-border bg-card/95 p-3 shadow-xl backdrop-blur-sm sm:inset-x-auto sm:bottom-auto sm:right-4 sm:top-4 sm:w-72"
+		>
+			<div class="mb-3 flex items-start gap-2">
+				<div class="min-w-0 flex-1">
+					<JobDefinitionCard
+						job={{ definition: selectedJob.definition, routeInfo: selectedJob.routeInfo }}
+						selected={true}
+						interactive={false}
+					/>
 				</div>
+				<button
+					type="button"
+					class="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+					onclick={clearSelection}
+					aria-label="Close job details"
+				>
+					<X class="h-4 w-4" />
+				</button>
+			</div>
 
-				{#if startError}
-					<div class="mt-2 rounded border border-destructive/30 bg-destructive/10 px-2 py-1 text-xs text-destructive">
-						{startError}
+			<div class="mb-2 text-xs font-medium text-muted-foreground">Available Monsters</div>
+			<div class="max-h-56 space-y-1.5 overflow-y-auto pr-1">
+				{#if availableMonsters.length === 0}
+					<div class="rounded border border-dashed border-border bg-muted px-2 py-2 text-xs text-muted-foreground">
+						All monsters are currently busy.
 					</div>
+				{:else}
+					{#each availableMonsters as monster (monster.entity?.id)}
+						{@const eta = estimateMonsterTravel(selectedJob, monster)}
+						<button
+							type="button"
+							class="w-full rounded border px-2 py-1.5 text-left text-xs transition {selectedMonsterId ===
+							monster.entity?.id
+								? 'border-primary/40 bg-secondary'
+								: 'border-border bg-card hover:border-border'}"
+							onclick={() => (selectedMonsterId = monster.entity?.id)}
+						>
+							<div class="font-medium text-foreground">{monster.identity?.name}</div>
+							<div class="text-muted-foreground">
+								Lv {monster.stat?.level} | Stamina {monster.stat?.stamina}/{monster.stat?.maxStamina}
+							</div>
+							<div class="text-muted-foreground">
+								Distance {Math.round(eta.distance * 100) / 100}m | ETA {formatDuration(eta.seconds)}
+							</div>
+						</button>
+					{/each}
 				{/if}
+			</div>
 
-				<div class="mt-3 flex gap-2">
-					<Button
-						class="flex-1 text-sm font-medium"
-						disabled={!selectedMonster || isStarting}
-						onclick={startSelectedJob}
-					>
-						{isStarting ? 'Starting...' : 'Start Job'}
-					</Button>
-					<button
-						type="button"
-						class="rounded border border-border px-3 py-2 text-sm text-foreground hover:bg-muted"
-						onclick={clearSelection}
-					>
-						Clear
-					</button>
-				</div>
-			{:else}
-				<div class="rounded border border-dashed border-border bg-muted px-3 py-6 text-sm text-muted-foreground">
-					Select a colored job pin on the map to open start controls.
+			{#if startError}
+				<div class="mt-2 rounded border border-destructive/30 bg-destructive/10 px-2 py-1 text-xs text-destructive">
+					{startError}
 				</div>
 			{/if}
+
+			<div class="mt-3">
+				<Button class="w-full text-sm font-medium" disabled={!selectedMonster || isStarting} onclick={startSelectedJob}>
+					{isStarting ? 'Starting...' : 'Start Job'}
+				</Button>
+			</div>
 		</aside>
-	</div>
+	{/if}
 </div>

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -11,5 +11,4 @@
 	]);
 </script>
 
-<h1>Map</h1>
 <Map {cities} {monsters} {productionJobs} {battleJobs} />


### PR DESCRIPTION
## Summary
- make the map fill the available content viewport
- float job filters and selected-job controls over the map
- simplify Pixi canvas ownership and terrain texture lookup
- improve responsive behavior and pin accessibility

## Verification
- npm run build
- npx eslint src/lib/components/map.svelte src/routes/map/+page.svelte
- npx prettier --check src/lib/components/map.svelte src/routes/map/+page.svelte
- visually verified desktop and narrow layouts

## Known issue
- npm run check still reports the pre-existing tuple-destructuring error in src/routes/monsters/+page.svelte